### PR TITLE
protection from API failure wasn't entirely effective...

### DIFF
--- a/commands/streaming.js
+++ b/commands/streaming.js
@@ -528,11 +528,11 @@ const Module = new Augur.Module()
             let game = (await twitch.games.getGameById(stream.gameId));
             if (game) twitchGames.set(game.id, game);
           }
-          stream.streamUrl = "https://www.twitch.tv/" + encodeURIComponent(name).toLowerCase();
+          stream.streamUrl = "https://www.twitch.tv/" + encodeURIComponent(name).toLowerCase().replace(/[^\w-]+/g,'');
           msg.channel.send(twitchEmbed(stream));
         } else { // Offline
           const streamer = (await twitch.users.getUserByName(name));
-          streamer.streamUrl = "https://www.twitch.tv/" + encodeURIComponent(name).toLowerCase();
+          streamer.streamUrl = "https://www.twitch.tv/" + encodeURIComponent(name).toLowerCase().replace(/[^\w-]+/g,'');
           msg.channel.send(twitchEmbed(streamer, false));
         }
       } catch(e) {


### PR DESCRIPTION
Removes characters that could easily be included in the URL that don't need to be there