### PR TITLE
The message will need to be attached to a client

### DIFF
--- a/commands/meme.js
+++ b/commands/meme.js
@@ -69,6 +69,7 @@ const Module = new Augur.Module()
               author: msg.author,
               attachments: msg.attachments,
               content: content,
+              client: msg.client,
               cleanContent: content
             };
             Module.client.commands.execute("meme", fakeMsg, content);


### PR DESCRIPTION
If the message is not attached to a client, then u.parse won't work and will get a null client user.